### PR TITLE
ubinfo: Return shell error status when volume not found

### DIFF
--- a/ubi-utils/ubinfo.c
+++ b/ubi-utils/ubinfo.c
@@ -414,7 +414,7 @@ int main(int argc, char * const argv[])
 
 	if (args.devn != -1 && args.vol_id != -1) {
 		print_vol_info(libubi, args.devn, args.vol_id);
-		goto out;
+		goto out_libubi;
 	}
 
 	if (args.devn == -1 && args.vol_id == -1)
@@ -425,7 +425,6 @@ int main(int argc, char * const argv[])
 	if (err)
 		goto out_libubi;
 
-out:
 	libubi_close(libubi);
 	return 0;
 


### PR DESCRIPTION
When looking up by other methods, ubinfo properly returns an error status. But
when looking up by volume ID, it doesn't return an error status to the shell.

# ubinfo /dev/ubi0 -n 0
ubinfo: error!: cannot get information about UBI volume 0 on ubi0
        error 2 (No such file or directory)
# echo $?
0

Signed-off-by: Russ Dill <russ.dill@gmail.com>